### PR TITLE
Powershell build scripts for compilation with Windows

### DIFF
--- a/clients/c++/build_win.ps1
+++ b/clients/c++/build_win.ps1
@@ -1,0 +1,1 @@
+g++ -std=c++17 -o http-client http-client.cpp -pthread -I../../lib/ -lWs2_32 -lssl -lcrypto -lCrypt32

--- a/models/testmodel/build_win.ps1
+++ b/models/testmodel/build_win.ps1
@@ -1,0 +1,1 @@
+g++ -std=c++17 -o minimal-server minimal-server.cpp -pthread -I../../lib/ -lWs2_32 -lssl -lcrypto -lCrypt32


### PR DESCRIPTION
This branch has Powershell build scripts, that can be used with Powershell to compile the c++ http-client and the minimal-server under MS Windows without WSL.