### PR TITLE
emcee functionality

### DIFF
--- a/clients/python/emcee-client.py
+++ b/clients/python/emcee-client.py
@@ -1,0 +1,33 @@
+import emcee
+from umbridge.emcee import UmbridgeLogProb
+import arviz as az
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+if __name__ == "__main__":
+
+    # Read URL from command line argument
+    parser = argparse.ArgumentParser(description='Minimal emcee sampler demo.')
+    parser.add_argument('url', metavar='url', type=str,
+                        help='the ULR on which the model is running, for example http://localhost:4242')
+    args = parser.parse_args()
+    print(f"Connecting to host URL {args.url}")
+
+    log_prob = UmbridgeLogProb(args.url)
+
+    nwalkers = 32
+    sampler = emcee.EnsembleSampler(nwalkers, log_prob.ndim, log_prob)
+
+    # run sampler
+    p0 = np.random.rand(nwalkers, log_prob.ndim)
+    state = sampler.run_mcmc(p0, 100)
+
+    # plot results
+    inference_data = az.from_emcee(sampler)
+    az.plot_pair(inference_data)
+    plt.tight_layout()
+    plt.savefig('emcee_inference.png')
+
+    print(az.summary(inference_data, round_to=2))        

--- a/umbridge/emcee.py
+++ b/umbridge/emcee.py
@@ -1,0 +1,17 @@
+import numpy as np
+import umbridge
+
+class UmbridgeLogProb():
+    def __init__(self, url, config = {}):
+        self.umbridge_model = umbridge.HTTPModel(url, 'posterior')
+        self.config = config
+        # For now, make sure model takes a single input vector and returns a single output vector.
+        # More could be supported, but needs improved aesara op.
+        # (i.e. adjust input/output types according to UM-Bridge model, pass through multiple vectors etc.)
+        assert len(self.umbridge_model.get_input_sizes(config)) == 1
+        assert len(self.umbridge_model.get_output_sizes(config)) == 1
+        self.ndim = self.umbridge_model.get_input_sizes(config)[0]
+
+    def __call__(self, *inputs):
+        model_output = self.umbridge_model([inputs[0].tolist()], self.config)
+        return np.asarray(model_output[0]).astype('float64')


### PR DESCRIPTION
I've added [emcee](https://emcee.readthedocs.io/) a python implementation of Goodman and Weare'a Affine Invariant MCMC Ensemble sampler) as a possible client. Currently tested on a simple gaussian example but should probably test against a few of the existing benchmarks!