### PR TITLE
Matlab webwrite can be much faster than http.send.

### DIFF
--- a/clients/matlab/ttClient.m
+++ b/clients/matlab/ttClient.m
@@ -1,11 +1,18 @@
+% Analytic-Banana benchmark. Approximate log-posterior density in TT format
 % Check for (and download) TT Toolbox
 check_tt;
 
 uri = 'http://localhost:4243';
-model = HTTPModel(uri,'posterior');
+model = HTTPModel(uri, 'posterior');
 
 % TT demo with umbridge model
-tol = 1e-6;
-x = linspace(-5,5,33);
-TTlogLikelihood = amen_cross(numel(x)*ones(2,1), @(i)model.evaluate(x(i)), tol, 'vec', false)
+tol = 1e-5;
+d = model.get_input_sizes
+x = linspace(-5,5,33); % A uniform grid on [-5,5]^d for analytic-banana
+% TTlogLikelihood = amen_cross(numel(x)*ones(d,1), @(i)model.evaluate(x(i)), tol, 'vec', false)
+tic;
+TTlogLikelihood = greedy2_cross(numel(x)*ones(d,1), @(i)model.evaluate(x(i)), tol, 'vec', false)
+toc
 
+% benchmark-analytic-banana: 44.138067 seconds with 'send' engine
+%                             4.250689 seconds with 'webwrite' engine

--- a/matlab/@HTTPModel/HTTPModel.m
+++ b/matlab/@HTTPModel/HTTPModel.m
@@ -3,22 +3,26 @@ classdef HTTPModel
 properties
 	uri
 	model_name
+    send_engine    % 'send' or 'webwrite'
 end
 
 methods
-	function model = HTTPModel(uri,model_name)
-        import matlab.net.*
-        import matlab.net.http.*
-
+    function model = HTTPModel(uri,model_name,send_engine)
         model.uri = uri;
         model.model_name = model_name;
+        if (nargin<3) || (isempty(send_engine))
+            model.send_engine = 'send';
+        else
+            model.send_engine = send_engine;
+        end
         
         % check protocol, make sure it's matching
-        r = RequestMessage;
-        uri = URI([uri, '/Info']);
+        uri = matlab.net.URI([uri, '/Info']);
+        r = matlab.net.http.RequestMessage;      % This must be GET
         resp = send(r,uri);
         HTTPModel.check_http_status(resp); % check if connection broke down
         json = jsondecode(resp.Body.string);
+
         if json.protocolVersion ~= 1
             error('the protocol version on the server side does not match the client')
         end        
@@ -45,6 +49,7 @@ end
 
 methods (Access=private)    
     output_json = get_model_info(self); 
+    output_json = send_data(self, uri, value);
 end
 
 methods (Static, Access=public)

--- a/matlab/@HTTPModel/apply_hessian.m
+++ b/matlab/@HTTPModel/apply_hessian.m
@@ -12,11 +12,7 @@ if (nargin<8) || (isempty(config))
     config = struct;
 end
 
-import matlab.net.*
-import matlab.net.http.*
-
 % Evaluate model
-r = RequestMessage('POST');
 if (isa(input, 'cell'))
     value.input = input;
 elseif (isa(input, 'double'))
@@ -35,11 +31,9 @@ value.inWrt1 = inWrt1;
 value.inWrt2 = inWrt2;
 value.outWrt = outWrt;
 value.config = config;
-r.Body = MessageBody(jsonencode(value));
-uri = URI([self.uri, '/ApplyHessian']);
-resp = send(r,uri);
-self.check_http_status(resp);
-json = jsondecode(resp.Body.string);
+value = jsonencode(value);
+uri = matlab.net.URI([self.uri, '/ApplyHessian']);
+json = self.send_data(uri, value);
 self.check_error(json);
 output = json.output;
 

--- a/matlab/@HTTPModel/apply_jacobian.m
+++ b/matlab/@HTTPModel/apply_jacobian.m
@@ -9,11 +9,7 @@ if (nargin<6) || (isempty(config))
     config = struct;
 end
 
-import matlab.net.*
-import matlab.net.http.*
-
 % Evaluate model
-r = RequestMessage('POST');
 if (isa(input, 'cell'))
     value.input = input;
 elseif (isa(input, 'double'))
@@ -30,11 +26,9 @@ value.vec = vec;
 value.inWrt = inWrt;
 value.outWrt = outWrt;
 value.config = config;
-r.Body = MessageBody(jsonencode(value));
-uri = URI([self.uri, '/ApplyJacobian']);
-resp = send(r,uri);
-self.check_http_status(resp);
-json = jsondecode(resp.Body.string);
+value = jsonencode(value);
+uri = matlab.net.URI([self.uri, '/ApplyJacobian']);
+json = self.send_data(uri, value);
 self.check_error(json);
 output = json.output;
 

--- a/matlab/@HTTPModel/evaluate.m
+++ b/matlab/@HTTPModel/evaluate.m
@@ -3,11 +3,7 @@ if (nargin<3) || (isempty(config))
     config = struct;
 end
 
-import matlab.net.*
-import matlab.net.http.*
-
-% Evaluate model
-r = RequestMessage('POST');
+% Parse inputs
 if (isa(input, 'cell'))
     value.input = input;
 elseif (isa(input, 'double'))
@@ -21,11 +17,10 @@ else
 end
 value.name = self.model_name;
 value.config = config;
-r.Body = MessageBody(jsonencode(value));
-uri = URI([self.uri, '/Evaluate']);
-resp = send(r,uri);
-self.check_http_status(resp);
-json = jsondecode(resp.Body.string);
+value = jsonencode(value);
+uri = matlab.net.URI([self.uri, '/Evaluate']);
+% Evaluate model
+json = self.send_data(uri, value);
 self.check_error(json);
 output = json.output;
 

--- a/matlab/@HTTPModel/get_model_info.m
+++ b/matlab/@HTTPModel/get_model_info.m
@@ -1,15 +1,8 @@
 function [output_json] = get_model_info(self)
 
-import matlab.net.*
-import matlab.net.http.*
-
-r = RequestMessage('POST');
 value.name = self.model_name;
-r.Body = MessageBody(jsonencode(value));
-uri = URI([self.uri,'/ModelInfo']);
-resp = send(r,uri);
-self.check_http_status(resp); % check if connection broke down
-json = jsondecode(resp.Body.string);
+uri = matlab.net.URI([self.uri,'/ModelInfo']);
+json = self.send_data(uri, jsonencode(value));
 self.check_error(json); % check if message came in but contains an error
 output_json = json.support;
 

--- a/matlab/@HTTPModel/gradient.m
+++ b/matlab/@HTTPModel/gradient.m
@@ -9,11 +9,7 @@ if (nargin<6) || (isempty(config))
     config = struct;
 end
 
-import matlab.net.*
-import matlab.net.http.*
-
 % Evaluate model
-r = RequestMessage('POST');
 if (isa(input, 'cell'))
     value.input = input;
 elseif (isa(input, 'double'))
@@ -30,11 +26,9 @@ value.sens = sens;
 value.inWrt = inWrt;
 value.outWrt = outWrt;
 value.config = config;
-r.Body = MessageBody(jsonencode(value));
-uri = URI([self.uri, '/Gradient']);
-resp = send(r,uri);
-self.check_http_status(resp);
-json = jsondecode(resp.Body.string);
+value = jsonencode(value);
+uri = matlab.net.URI([self.uri, '/Gradient']);
+json = self.send_data(uri, value);
 self.check_error(json);
 output = json.output;
 

--- a/matlab/@HTTPModel/send_data.m
+++ b/matlab/@HTTPModel/send_data.m
@@ -1,0 +1,16 @@
+function output_json = send_data(self, uri, value)
+if strcmpi(self.send_engine, 'send')
+    r = matlab.net.http.RequestMessage('POST');
+    r.Body = matlab.net.http.MessageBody(value);
+    resp = send(r, uri);
+    self.check_http_status(resp);
+    output_json = jsondecode(resp.Body.string);
+else
+    opts = weboptions('Timeout', inf, 'RequestMethod', 'POST');
+    opts.MediaType = 'application/json';
+    output_json = webwrite(uri, value, opts);
+    if ~isa(output_json, 'struct')
+        output_json = jsondecode(output_json);
+    end
+end
+end

--- a/matlab/umbridge_supported_models.m
+++ b/matlab/umbridge_supported_models.m
@@ -1,13 +1,12 @@
 function [model_names] = umbridge_supported_models(uri)
-import matlab.net.*
-import matlab.net.http.*
-
 % Get model info
-r = RequestMessage;
-uri = URI([uri, '/Info']);
+uri = matlab.net.URI([uri, '/Info']);
+
+r = matlab.net.http.RequestMessage;  % This needs to be GET
 resp = send(r,uri);
 HTTPModel.check_http_status(resp); % check if connection broke down
 json = jsondecode(resp.Body.string);
+
 HTTPModel.check_error(json); % check if message came in but contains an error
 model_names = json.models;
 


### PR DESCRIPTION
ttClient for benchmark-analytic-banana: 
44.138067 seconds with 'send' http engine
4.250689 seconds with 'webwrite' http engine

As a by-product, tidy up http request code into one send_data function.

However, ttClient and constructor are defaulted to the old 'send' engine for CI & debugging. The issue with webwrite is that it flags all non-OK http statuses as errors, preventing differentiation between 'true' http errors and umbridge (model) errors.