### PR TITLE
Initialize hyperqueue and its allocation queue only once

### DIFF
--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -31,13 +31,6 @@ std::string get_hostname() {
 }
 
 const std::vector<std::string> get_model_names() {
-    // Setup HyperQueue server
-    std::system("hq server start &");
-    sleep(1); // Workaround: give the HQ server enough time to start.
-
-    // Create allocation queue
-    std::system("hq_scripts/allocation_queue.sh");
-
     HyperQueueJob hq_job("", false); // Don't start a client.
 
     return umbridge::SupportedModels(hq_job.server_url);
@@ -49,6 +42,12 @@ int main(int argc, char *argv[])
     create_directory_if_not_existing("sub-jobs");
     clear_url("urls");
     std::system("hq server stop &> /dev/null");
+
+    std::system("hq server start &");
+    sleep(1); // Workaround: give the HQ server enough time to start.
+
+    // Create HQ allocation queue
+    std::system("hq_scripts/allocation_queue.sh");
 
     // Read environment variables for configuration
     char const *port_cstr = std::getenv("PORT");

--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -30,6 +30,16 @@ std::string get_hostname() {
     return std::string(hostname);
 }
 
+void launch_hq_with_alloc_queue() {
+    std::system("hq server stop &> /dev/null");
+
+    std::system("hq server start &");
+    sleep(1); // Workaround: give the HQ server enough time to start.
+
+    // Create HQ allocation queue
+    std::system("hq_scripts/allocation_queue.sh");
+}
+
 const std::vector<std::string> get_model_names() {
     HyperQueueJob hq_job("", false); // Don't start a client.
 
@@ -41,13 +51,8 @@ int main(int argc, char *argv[])
     create_directory_if_not_existing("urls");
     create_directory_if_not_existing("sub-jobs");
     clear_url("urls");
-    std::system("hq server stop &> /dev/null");
 
-    std::system("hq server start &");
-    sleep(1); // Workaround: give the HQ server enough time to start.
-
-    // Create HQ allocation queue
-    std::system("hq_scripts/allocation_queue.sh");
+    launch_hq_with_alloc_queue();
 
     // Read environment variables for configuration
     char const *port_cstr = std::getenv("PORT");

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -153,15 +153,7 @@ private:
 class LoadBalancer : public umbridge::Model
 {
 public:
-    LoadBalancer(std::string name) : umbridge::Model(name)
-    {
-        // Setup HyperQueue server
-        std::system("hq server start &");
-        sleep(1); // Workaround: give the HQ server enough time to start.
-
-        // Create allocation queue
-        std::system("hq_scripts/allocation_queue.sh");
-    }
+    LoadBalancer(std::string name) : umbridge::Model(name) {}
 
     std::vector<std::size_t> GetInputSizes(const json &config_json = json::parse("{}")) const override
     {


### PR DESCRIPTION
Start hyperqueue server and initalize alloc queue only once at load balancer start. Previously happened once to get model names, and then once per model name.

Fixed #40 .