### PR TITLE
Add support for model specific job submission scripts

### DIFF
--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -35,7 +35,8 @@ void launch_hq_with_alloc_queue() {
 }
 
 const std::vector<std::string> get_model_names() {
-    HyperQueueJob hq_job("", false); // Don't start a client.
+    // Don't start a client, always use the default job submission script.
+    HyperQueueJob hq_job("", false, true); 
 
     return umbridge::SupportedModels(hq_job.server_url);
 }


### PR DESCRIPTION
Added support for model specific job submission scripts:
- HQ job submissions now use `hq_scripts/job_<model_name>.sh` if such a file exists and `hq_scripts/job.sh` as a default otherwise.
- There is an option to always use the default job script, which is currently only used by the initial HQ job that determines the available models.
    - Therefore, the default `hq_scripts/job.sh` file is still always required! ⚠️
    - The load balancer will throw an exception if the default `hq_script/job.sh` file doesn't exist.

Possible issues:
- There is currently no protection against typos in the name of a model specific job submission script. ⚠️ 
    - Could add console output whenever a fallback to the default job submission script occurs. However, this would clutter the output a lot.
    - Best solution would probably be to add proper logging, but that would be a bigger project (not a priority at the moment).