### PR TITLE
Fix issue 48

### DIFF
--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -86,6 +86,6 @@ int main(int argc, char *argv[])
     std::transform(LB_vector.begin(), LB_vector.end(), LB_ptr_vector.begin(),
                    [](LoadBalancer& obj) { return &obj; });
 
-    std::cout << "Load balancer running port" << port << std::endl;
+    std::cout << "Load balancer running port " << port << std::endl;
     umbridge::serveModels(LB_ptr_vector, "0.0.0.0", port, true, false);
 }

--- a/hpc/Makefile
+++ b/hpc/Makefile
@@ -6,6 +6,8 @@ build-load-balancer:
 	- g++ -O3 -Wno-unused-result -std=c++17 $(load-balancer-files) -o load-balancer -pthread
 
 run-load-balancer:
+	rm -f retry-respond-job_id.txt
+
 	if ! printenv PORT > /dev/null; then \
 	echo "PORT environment variable not set. Using default value 4242."; \
 	export PORT=4242; \

--- a/hpc/Makefile
+++ b/hpc/Makefile
@@ -4,3 +4,15 @@ load-balancer-files = LoadBalancer.cpp LoadBalancer.hpp ../lib/httplib.h ../lib/
 
 build-load-balancer:
 	- g++ -O3 -Wno-unused-result -std=c++17 $(load-balancer-files) -o load-balancer -pthread
+
+run-load-balancer:
+	if ! printenv PORT > /dev/null; then \
+	echo "PORT environment variable not set. Using default value 4242."; \
+	export PORT=4242; \
+	fi && \
+	export HQ_SUBMIT_DELAY_MS=100 && \
+	while nc -z localhost $$PORT; do \
+		read -p "Port $$PORT is already in use. Please enter a different port: " NEW_PORT; \
+		PORT=$${NEW_PORT:-$$PORT}; \
+	done; \
+	./load-balancer

--- a/hpc/test/MultiplyBy2/Makefile
+++ b/hpc/test/MultiplyBy2/Makefile
@@ -1,0 +1,26 @@
+all: build-server build-lb run
+
+load-balancer-files = ../../LoadBalancer.cpp ../../LoadBalancer.hpp ../../../lib/httplib.h ../../../lib/json.hpp ../../../lib/umbridge.h
+
+build-server:
+	g++ -O3 -w -std=c++11 minimal-server.cpp -o server -lssl -lcrypto -pthread
+
+build-lb:
+	g++ -O3 -Wno-unused-result -std=c++17 $(load-balancer-files) -o ../../load-balancer -pthread
+
+run:
+	rm -f retry-port-job_id.txt
+	rm -f retry-respond-job_id.txt
+	mkdir -p logs
+	rm -f logs/*
+
+	if ! printenv PORT > /dev/null; then \
+		echo "PORT environment variable not set. Using default value 4242."; \
+		export PORT=4242; \
+	fi && \
+	export HQ_SUBMIT_DELAY_MS=100 && \
+	while nc -z localhost $$PORT; do \
+		read -p "Port $$PORT is already in use. Please enter a different port: " NEW_PORT; \
+		PORT=$${NEW_PORT:-$$PORT}; \
+	done; \
+	cd ../../ && ./load-balancer

--- a/hpc/test/MultiplyBy2/client.sh
+++ b/hpc/test/MultiplyBy2/client.sh
@@ -1,0 +1,31 @@
+#!/bin/bash 
+
+# export TEST_DELAY=1e4
+
+if [ -z "$PORT" ]; then
+        PORT="4242"
+    fi
+
+echo "Using URL http://localhost:$PORT"
+
+echo "Sending requests..." 
+
+for i in {1..300} 
+do 
+   # Expected output: {"output":[[200.0]]} 
+   # Check if curl output equals expected output 
+   # If not, print error message 
+ 
+   if [ "$(curl -s http://localhost:$PORT/Evaluate -X POST -d '{"name": "forward", "input": [[100.0]]}')" == '{"output":[[200.0]]}' ]; then 
+       echo -n "y" 
+   else 
+       echo $(curl -s http://localhost:$PORT/Evaluate -X POST -d '{"name": "forward", "input": [[100.0]]}')
+       echo -n "n" 
+       #echo "Error: curl output does not equal expected output" 
+   fi & 
+ 
+done 
+ 
+echo "Requests sent. Waiting for responses..." 
+ 
+wait

--- a/hpc/test/MultiplyBy2/job.sh
+++ b/hpc/test/MultiplyBy2/job.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+#HQ --cpus=1
+#HQ --time-request=1m
+#HQ --time-limit=2m
+#HQ --stdout %{CWD}/test/MultiplyBy2/logs/job-%{JOB_ID}.out
+#HQ --stderr %{CWD}/test/MultiplyBy2/logs/job-%{JOB_ID}.err
+
+# Launch model server, send back server URL
+# and wait to ensure that HQ won't schedule any more jobs to this allocation.
+
+
+# Define the range of ports to select from
+MIN_PORT=49152
+MAX_PORT=65535
+# Generate a random port number
+port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
+# Check if the port is in use
+try_count=0
+echo "$(lsof -Pi :$port -sTCP:LISTEN -t )"
+while [ -n  "$(lsof -Pi :$port -sTCP:LISTEN -t )" ]
+do
+    echo "Port $port is in use, trying another port"
+    # If the port is in use, generate a new port number
+    port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
+
+    try_count=$((try_count+1))
+
+    echo "$HQ_JOB_ID" > "./test/MultiplyBy2/retry-port-job_id.txt"
+done
+echo "Selected port $port after $try_count tries"
+
+echo "Starting server on port $port"
+export PORT=$port
+
+# Assume that server sets the port according to the environment variable 'PORT'.
+./test/MultiplyBy2/server & # CHANGE ME!
+
+load_balancer_dir="./" # CHANGE ME!
+
+host=$(hostname -I | awk '{print $1}')
+
+timeout=30 # timeout in seconds
+echo "Waiting for model server to respond at $host:$port..."
+if timeout $timeout sh -c 'while ! curl -s "http://'"$host"':'"$port"'/Info" > /dev/null ; do :; done'; then
+    echo "Model server responded within $timeout seconds"
+else
+    echo "Timeout: Model server did not respond within $timeout seconds"
+    echo "$HQ_JOB_ID" > "./test/MultiplyBy2/retry-respond-job_id.txt"
+    
+    # clear the server here if needed
+
+    # restart the job
+    $load_balancer_dir/hq_scripts/job.sh
+fi
+
+# Write server URL to file identified by HQ job ID.
+mkdir -p "$load_balancer_dir/urls"
+echo "http://$host:$port" > "$load_balancer_dir/urls/url-$HQ_JOB_ID.txt"
+
+sleep infinity # keep the job occupied


### PR DESCRIPTION
## The issue

Issue #48  was about sporadic model crashes on Helix. When using `load-balancer` to start the servers, the server occasionally fails to start because the randomly selected port is in use. 

## Debugging 

I found that some ports were vacant when checking and occupied when the server was trying to use them. It should be the case that some processes occupied the port just between the checking and using.

I noticed that some jobs did try to select a new port during the test, so the checking part should be correct.

## Solution

I tried to occupy the port using `nc -l $port &`  when checking and then release it just before the start of the server, but the releasing using `fuser -k -n tcp $port` was not stable (on Helix). Therefore, I didn't use this approach.

Instead, I added a timeout check in `job.sh` to see if the script waits for a server to respond exceeds `$timeout` seconds. If so, the script will call itself again to restart the server.

Since the issue #48 only happens (around) once every hundred times, the usage time should not increase significantly. Also, since there's a time limit for HQ jobs set in the `job.sh`, this retry won't repeat infinitely.

Just need to notice that if there are too many servers need to restart, it might be because that the `$timeout` set in `job.sh` is too small to start the server.

## Other changes

- Added a PORT check in the Makefile before executing the `load-balancer`. Since there was no error message when the port of `load-balancer` was occupied. (Also set `HQ_SUBMIT_DELAY` to 100ms) 
- Added my codes for debugging using `MultiplyBy2` in the `test` folder.