### PR TITLE
HPC: Multiple Backends

### DIFF
--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
     
     // Assemble job manager
     std::unique_ptr<JobSubmitter> job_submitter;
-    std::string script_dir;
+    std::filesystem::path script_dir;
     if (scheduler == "hyperqueue") {
         launch_hq_with_alloc_queue();
         job_submitter = std::make_unique<HyperQueueSubmitter>(delay);

--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -20,7 +20,7 @@ void launch_hq_with_alloc_queue() {
     std::system("./hq server stop &> /dev/null");
 
     std::system("./hq server start &");
-
+    // Wait for the HQ server to start
     std::system("until ./hq server info &> /dev/null; do sleep 1; done");
 
     // Create HQ allocation queue
@@ -110,8 +110,7 @@ int main(int argc, char* argv[]) {
 
     // Prepare models and serve via network
     std::vector<LoadBalancer> LB_vector;
-    for (auto model_name : model_names)
-    {
+    for (auto model_name : model_names) {
         LB_vector.emplace_back(model_name, job_manager);
     }
 

--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -11,12 +11,6 @@
 
 #include "../lib/umbridge.h"
 
-void create_directory_if_not_existing(std::string directory) {
-    if (!std::filesystem::is_directory(directory) || !std::filesystem::exists(directory)) {
-        std::filesystem::create_directory(directory);
-    }
-}
-
 void clear_url(std::string directory) {
     for (auto& file : std::filesystem::directory_iterator(directory)) {
         if (std::regex_match(file.path().filename().string(), std::regex("url-\\d+\\.txt"))) {
@@ -28,98 +22,15 @@ void clear_url(std::string directory) {
 void launch_hq_with_alloc_queue() {
     std::system("./hq server stop &> /dev/null");
 
-    std::system("./hq server start &");
-    sleep(1); // Workaround: give the HQ server enough time to start.
+    std::system("until ./hq server info &> /dev/null; do sleep 1; done");
 
     // Create HQ allocation queue
     std::system("hq_scripts/allocation_queue.sh");
 }
 
-const std::vector<std::string> get_model_names() {
-    // Don't start a client, always use the default job submission script.
-    HyperQueueJob hq_job("", false, true); 
-
-    return umbridge::SupportedModels(hq_job.server_url);
-}
-
-void print_model_and_job_script_information(const std::vector<std::string>& model_names) {
-    // Constants
-    const std::filesystem::path SUBMISSION_SCRIPT_DIR("./hq_scripts");
-    const std::filesystem::path SUBMISSION_SCRIPT_GENERIC("job.sh");
-
-    const std::string SECTION_START_DELIMITER = "==============================MODEL INFO==============================";
-    const std::string SECTION_END_DELIMITER   = "======================================================================";
-    
-    // Sort the model names in alphabetical order for cleaner output.
-    std::vector<std::string> model_names_sorted = model_names;
-    std::sort(model_names_sorted.begin(), model_names_sorted.end());
-
-    std::cout << SECTION_START_DELIMITER << "\n";
-    // Print list of available models and corresponding job-scripts.
-    std::cout << "Available models and corresponding job-scripts:\n";
-    for (const std::string& model_name : model_names_sorted) {
-        // Determine which job script will be used by checking if a model specific job script exists.
-        std::string used_job_script;
-        const std::filesystem::path submission_script_model_specific("job_" + model_name + ".sh");
-        if (std::filesystem::exists(SUBMISSION_SCRIPT_DIR / submission_script_model_specific)) {
-            used_job_script = submission_script_model_specific.string();
-        } else {
-            used_job_script = SUBMISSION_SCRIPT_GENERIC.string();
-        }
-        std::cout << "* Model '" << model_name << "' --> '" << used_job_script << "'\n";
-    }
-    std::cout << std::endl;
-    
-
-    // Check if there are job scripts that are unused and print a warning.
-    std::vector<std::string> unused_job_scripts;
-
-    // Build a regex to parse job-script filenames and extract the model name.
-    // Format should be: job_<model_name>.sh
-    const std::string format_prefix = "^job_"; // Ensures that filename starts with 'job_'.
-    const std::string format_suffix = "\\.sh$"; // Ensures that filename ends with '.sh'.
-    const std::string format_model_name = "(.*)"; // Arbitrary sequence of characters as a marked subexpression.
-    const std::regex format_regex(format_prefix + format_model_name + format_suffix);
-
-    for (auto& file : std::filesystem::directory_iterator(SUBMISSION_SCRIPT_DIR)) {
-        const std::string filename = file.path().filename().string();
-        // Check if filename matches format of a model specific job script, i.e. 'job_<model_name>.sh'.
-        std::smatch match_result;
-        if (std::regex_search(filename, match_result, format_regex)) {
-            // Extract first matched subexpression, i.e. the model name.
-            const std::string model_name = match_result[1].str(); 
-            // Check if a corresponding model exists. If not, mark job script as unused.
-            if (!std::binary_search(model_names_sorted.begin(), model_names_sorted.end(), model_name)) {
-                unused_job_scripts.push_back(filename);
-            }
-        }
-    }
-
-    // Print the warning message.
-    if(!unused_job_scripts.empty()) {
-        // Sort unused job scripts alphabetically for cleaner output.
-        std::sort(unused_job_scripts.begin(), unused_job_scripts.end());
-
-        std::cout << "WARNING: The following model-specific job-scripts are not used by any of the available models:\n";
-        for (const std::string& job_script : unused_job_scripts) {
-            std::cout << "* '" << job_script << "'\n";
-        }
-        std::cout << std::endl;
-
-        std::cout << "If this behavior is unintentional, then please verify that:\n"
-                  << "1. The filename of your model-specific job-script follows the format: 'job_<your_model_name>.sh' (e.g. 'job_mymodel.sh')\n"
-                  << "2. The spelling of your model name matches in the model definition and in the filename of your model-specific job-script.\n";
-    }
-
-    std::cout << SECTION_END_DELIMITER << std::endl;
-}
-
-std::atomic<int32_t> HyperQueueJob::job_count = 0;
 
 int main(int argc, char *argv[])
 {
-    create_directory_if_not_existing("urls");
-    create_directory_if_not_existing("sub-jobs");
     clear_url("urls");
 
     launch_hq_with_alloc_queue();
@@ -137,25 +48,24 @@ int main(int argc, char *argv[])
         port = atoi(port_cstr);
     }
 
-    char const *delay_cstr = std::getenv("HQ_SUBMIT_DELAY_MS");
-    if (delay_cstr != NULL)
-    {
-        hq_submit_delay_ms = atoi(delay_cstr);
-    }
-    std::cout << "HQ_SUBMIT_DELAY_MS set to " << hq_submit_delay_ms << std::endl;
+    JobScriptLocator locator {"hq_scripts", "job.sh", "job_", ".sh"};
+    std::shared_ptr<JobManager> job_manager = std::make_shared<CommandJobManager>(
+        std::make_unique<HyperQueueSubmitter>(std::chrono::milliseconds(100)),
+        std::make_unique<FilesystemCommunicatorFactory>("urls", std::chrono::milliseconds(100)),
+        locator
+    );
 
     // Initialize load balancer for each available model on the model server.
-    const std::vector<std::string> model_names = get_model_names();
+    std::vector<std::string> model_names = job_manager->getModelNames();
 
     // Inform the user about the available models and the job scripts that will be used.
-    // Output a warning for unused model-specific job-scripts to prevent typos.
-    print_model_and_job_script_information(model_names);
+    locator.printModelJobScripts(model_names);    
 
     std::vector<LoadBalancer> LB_vector;
     for (auto model_name : model_names)
     {
         // Set up and serve model
-        LB_vector.emplace_back(LoadBalancer{model_name});
+        LB_vector.emplace_back(model_name, job_manager);
     }
 
     // umbridge::serveModels currently only accepts raw pointers.

--- a/hpc/LoadBalancer.cpp
+++ b/hpc/LoadBalancer.cpp
@@ -22,6 +22,8 @@ void clear_url(std::string directory) {
 void launch_hq_with_alloc_queue() {
     std::system("./hq server stop &> /dev/null");
 
+    std::system("./hq server start &");
+
     std::system("until ./hq server info &> /dev/null; do sleep 1; done");
 
     // Create HQ allocation queue

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -75,8 +75,39 @@ public:
     // Therefore, the implementation can most likely use the same mechanism that is also used for granting model access.
     virtual std::vector<std::string> getModelNames() = 0;
 
-    virtual ~JobManager() {};
+    virtual ~JobManager() = default;
 };
+
+class FileBasedJob
+{
+public:
+    FileBasedJob()
+    {
+
+    }
+
+    FileBaseJob~()
+    {
+
+    }
+
+    FileBasedJob(const FileBasedJob& other) = delete;
+
+    std::string getJobID() const 
+    {
+        return job_id;
+    }
+private:
+    std::string job_id;
+};
+
+template<typename T>
+void deleteFileBased(T* t, std::string file_to_delete, std::string cancellation_command)
+{
+    delete t;
+    std::filesystem::remove(file_to_delete);
+    std::system(cancelation_command.c_str());
+}
 
 class FileBasedJobManager : public JobManager
 {
@@ -118,7 +149,7 @@ protected:
     std::string submitJob()
     {
         // Add optional delay to job submissions to prevent issues in some cases.
-        if (submission_delay_ms) {
+        if (submission_delay_ms > 0) {
             std::lock_guard<std::mutex> lock(submission_mutex);
             std::this_thread::sleep_for(std::chrono::milliseconds(submission_delay_ms));
         }

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -78,37 +78,45 @@ public:
     virtual ~JobManager() = default;
 };
 
-class FileBasedJob
+class Job
 {
 public:
-    FileBasedJob()
+    virtual ~Job() = default;
+
+    virtual std::string getJobId() const = 0;
+};
+
+
+class FileBasedJob : public Job
+{
+public:
+    FileBasedJob(const std::string& command, std::function<std::string (const std::string&)> extract_job_id)
+    {
+        std::string command_output = getCommandOutput(command);
+        id = extract_job_id(command_output);
+    }
+
+    ~FileBasedJob()
     {
 
     }
-
-    FileBaseJob~()
-    {
-
-    }
-
-    FileBasedJob(const FileBasedJob& other) = delete;
-
-    std::string getJobID() const 
-    {
-        return job_id;
-    }
-private:
-    std::string job_id;
+protected:
+    std::string id;
 };
 
 template<typename T>
-void deleteFileBased(T* t, std::string file_to_delete, std::string cancellation_command)
+void deleteFileBased(T* t, std::string file_to_delete, std::string cancel_command)
 {
     delete t;
     std::filesystem::remove(file_to_delete);
-    std::system(cancelation_command.c_str());
+    std::system(cancel_command.c_str());
 }
 
+// Basic idea:
+// 1. Run some command to request a resource allocation on the HPC cluster.
+// 2. Launch a model server in the resource allocation.
+// 3. Retrieve the URL of the model server.
+// 4. Connect to the model server using the URL.
 class FileBasedJobManager : public JobManager
 {
 public:

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -65,15 +65,33 @@ std::string readUrl(const std::string &filename)
     return url;
 }
 
+class JobManager
+{
+public:
+    virtual std::unique_ptr<umbridge::Model> requestModelAccess(const std::string& model_name) = 0;
+    virtual std::vector<std::string> getModelNames() = 0;
+    virtual ~JobManager() {};
+};
+
+class HyperQueueJobManager : public JobManager
+{
+public:
+    virtual std::unique_ptr<umbridge::Model> requestModelAccess(const std::string& model_name) override
+    {
+        return std::make_unique<HyperQueueJob>(model_name);
+    }
+};
+
 std::mutex job_submission_mutex;
 int hq_submit_delay_ms = 0;
 
-class HyperQueueJob
+class HyperQueueJob : public umbridge::Model
 {
 public:
     static std::atomic<int32_t> job_count;
     HyperQueueJob(std::string model_name, bool start_client=true, 
                                           bool force_default_submission_script=false)
+    : Model(model_name)
     {
         job_id = submitHQJob(model_name, force_default_submission_script);
 

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -113,10 +113,11 @@ class HyperQueueJob : public Job
 public:
     explicit HyperQueueJob(const std::vector<std::string>& options, const std::string& target)
     {
-        Command command {"./hq", options, target};
+        Command command {"./hq submit", options, target};
 
         // Makes HQ output "<job id>\n"
         command.addOption("--output-mode=quiet");
+        std::cout << "Running command: " << command.toString() << std::endl;
         id = get_command_output(command.toString());
 
         remove_trailing_newline(id);
@@ -189,7 +190,7 @@ public:
 
         // Submit job and increase job count
         std::vector<std::string> options = env_to_options(env);
-        options.emplace_back("--priority=-" + job_count);
+        options.emplace_back("--priority=-" + std::to_string(job_count));
         std::unique_ptr<Job> job = std::make_unique<HyperQueueJob>(options, job_script);
         job_count++;
         return job;

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -1,6 +1,6 @@
 # HPC
 
-This load balancer allows any scaling up UM-Bridge applications to HPC systems. To the client, it behaves like a regular UM-Bridge server, except that i can process concurrent model evaluation requests. When it receives requests, it will adaptively spawn model server instances on the HPC system, and forward evaluation requests to them. To each model server instance, the load balancer in turn appears as a regular UM-Bridge client.
+This load balancer allows scaling up any UM-Bridge application to HPC systems. To the client, it behaves like a regular UM-Bridge server, except that it can process concurrent model evaluation requests. When it receives requests, it will adaptively spawn model server instances on the HPC system, and forward evaluation requests to them. To each model server instance, the load balancer in turn appears as a regular UM-Bridge client.
 
 ## Installation
 
@@ -8,35 +8,59 @@ This load balancer allows any scaling up UM-Bridge applications to HPC systems. 
 
    Clone the UM-Bridge repository.
 
-   ```
+   ```shell
    git clone https://github.com/UM-Bridge/umbridge.git
    ```
 
    Then navigate to the `hpc` directory.
 
-   ```
+   ```shell
    cd umbridge/hpc
    ```
 
-   Finally, compile the load balancer. Depending on your HPC system, you likely have to load a module providing a recent c++ compiler.
+   Finally, compile the load balancer. Depending on your HPC system, you likely have to load a module providing a recent C++ compiler.
 
-   ```
+   ```shell
    make
    ```
 
-2. **Download HyperQueue**
+   Once compilation is finished, you should have a `load-balancer` binary in your `umbridge/hpc` directory. It provides a simple CLI for launching and configuring the load balancer.
+2. **(Optional) Download HyperQueue**
 
-   Download HyperQueue from the most recent release at [https://github.com/It4innovations/hyperqueue/releases](https://github.com/It4innovations/hyperqueue/releases) and place the `hq` binary in the `hpc` directory next to the load balancer.
+   If you wish to use the HyperQueue scheduler, download HyperQueue from the most recent release at [https://github.com/It4innovations/hyperqueue/releases](https://github.com/It4innovations/hyperqueue/releases) and place the `hq` binary in the `hpc` directory next to the load balancer.
+
 
 ## Usage
 
-The load balancer is primarily intended to run on a login node.
+### Choosing a suitable scheduler
+
+You must first decide which scheduling strategy the load balancer should use. Here is a summary of the available options:
+
+* **SLURM** - Easy to setup, but slow for very quick models
+* **HyperQueue** - Can be trickier to setup, but much more powerful
+
+We recommend trying out the simple SLURM scheduler first, before switching to the HyperQueue scheduler, if the performance is not good enough.
+
+### (Option 1) SLURM scheduler
+
+The load balancer will submit a new SLURM job for each incoming model request. Note that this can incur a sizable overhead, especially if your cluster is busy, so consider switching to the HyperQueue scheduler if your individual model runs are very short.
+
+To setup the SLURM scheduler, simply adjust the SLURM job script in `hpc/slurm_scripts/job.sh` to your needs:
+
+* Specify what UM-Bridge model server to run,
+* and set `#SBATCH` variables at the top to specify what resources each instance should receive.
+
+Importantly, the UM-Bridge model server must serve its models at the port specified by the environment variable `PORT`. The value of `PORT` is automatically determined by `job.sh`, avoiding potential conflicts if multiple servers run on the same compute node.
+
+Also, make sure that the job script complies with the requirements of your cluster (e.g. setting credentials, partition, etc.). You can test if your job script works correctly by submitting it as usual using `sbatch`.
+
+### (Option 2) HyperQueue scheduler
 
 1. **Configure resource allocation**
 
    The load balancer instructs HyperQueue to allocate batches of resources on the HPC system, depending on demand for model evaluations. HyperQueue will submit SLURM or PBS jobs on the HPC system when needed, scheduling requested model runs within those jobs. When demand decreases, HyperQueue will cancel some of those jobs again.
 
-   Adapt the configuration in ``hpc/hq_scripts/allocation_queue.sh`` to your needs.
+   Adapt the configuration in ``hpc/hq_scripts/allocation_queue.sh`` to your needs by setting options in the `hq alloc add` command (see the section on [resource management](#resource-management-with-hyperqueue) down below for more detailed instructions).
 
    For example, when running a very fast UM-Bridge model on an HPC cluster, it is advisable to choose medium-sized jobs for resource allocation. That will avoid submitting large numbers of jobs to the HPC system's scheduler, while HyperQueue itself will handle large numbers of small model runs within those allocated jobs.
 
@@ -48,29 +72,89 @@ The load balancer is primarily intended to run on a login node.
 
    Importantly, the UM-Bridge model server must serve its models at the port specified by the environment variable `PORT`. The value of `PORT` is automatically determined by `job.sh`, avoiding potential conflicts if multiple servers run on the same compute node.
 
-   If your job is supposed to span multiple compute nodes via MPI, make sure that you forward the nodes HyperQueue allocates to you in `HQ_NODE_FILE` to MPI. See [https://it4innovations.github.io/hyperqueue/stable/jobs/multinode/](https://it4innovations.github.io/hyperqueue/stable/jobs/multinode/#running-mpi-tasks) for instructions.
+   If your job is supposed to span multiple compute nodes via MPI, make sure that you forward the nodes HyperQueue allocates to you in `HQ_NODE_FILE` to MPI. See the [HyperQueue documentation](https://it4innovations.github.io/hyperqueue/stable/jobs/multinode/#running-mpi-tasks) for further instructions. Also check out the section on [MPI tasks with HyperQueue under SLURM](#optional-launching-mpi-tasks-with-hyperqueue-under-slurm) to learn about some common pitfalls if you intend to run your model on a system with SLURM.
 
-4. **Run load balancer**
+### Running the load balancer
 
-   Navigate to the `hpc` directory and execute the load balancer.
+1. **Launch the load balancer on the login node**
 
+   Navigate to the `hpc` directory and execute the load balancer with your desired arguments. Note that specifying a scheduler is mandatory.
+
+   ```shell
+   ./load-balancer --scheduler=slurm # Use the SLURM scheduler
+   ./load-balancer --scheduler=hyperqueue # Use the HyperQueue scheduler
    ```
-   ./load-balancer
+   The other optional arguments the load balancer accepts are:
+   ```shell
+   --port=1234 # Run load balancer on the specified port instead of the default 4242
+   --delay-ms=100 # Set a delay (in milliseconds) for job submissions. Useful if too many rapid job submissions cause stability issues.
    ```
 
-5. **Connect from client**
+4. **Connect from client**
 
    Once running, you can connect to the load balancer from any UM-Bridge client on the login node via `http://localhost:4242`. To the client, it will appear like any other UM-Bridge server, except that it can process concurrent evaluation requests.
 
+## Resource management with HyperQueue
+
+### Specifying HyperQueue worker resources
+
+Each HyperQueue worker created by an allocation queue gets assigned a set of resources. A HyperQueue job may request resources and will only be scheduled to workers which have enough resources to fulfill the request. These resources are **purely logical** and are only used for scheduling in HyperQueue. **There is no inherent connection to actual hardware resources!**
+
+HyperQueue can automatically detect certain generic resources like CPUs, GPUs and memory. However, this mechanism may not work on all types of hardware. We recommend the much more robust approach of manually specifying resources for HyperQueue workers in `hpc/hq_scripts/allocation_queue.sh`. Please refer to the [HyperQueue documentation](https://it4innovations.github.io/hyperqueue/stable/jobs/resources/) to find out how to manually specify resources.
+
+### Requesting hardware resources with a job manager (SLURM/PBS)
+
+As stated in the previous section, resources assigned to workers do not correspond to actual hardware. If you want to run your model on a system that uses a job manager (e.g. SLURM or PBS), then you also need to request hardware resources from your job manager and ensure that these match with the logical resources assigned to each worker.
+
+The following section assumes that your system is using SLURM as a job manager, but a similar approach should also apply to other job managers like PBS:
+
+An allocation queue will automatically submit and cancel SLURM job allocations depending on the number of incoming requests received by the load balancer. HyperQueue will spawn exactly one worker per node inside each SLURM job allocation. Therefore, you should **always specify hardware resources on a per node basis** to ensure that each HyperQueue worker has the same logical and hardware resources.
+
+You can configure hardware resources in `hpc/hq_scripts/allocation_queue.sh` by passing options to the `hq alloc add` command or directly to SLURM (everything after the `--` at the end). Here is a summary of the options you should and should not use to properly specify hardware resources:
+
+* Always use the `--time-limit` parameter from HyperQueue instead of directly passing `--time` to SLURM.
+* Always use the `--workers-per-alloc` parameter from HyperQueue instead of directly passing `--nodes` to SLURM.
+* Never use SLURM's `--ntasks` or `--ntasks-per-node` since this will prevent HyperQueue from correctly spawning exactly one worker per node.
+* Instead, use SLURM's `--cpus-per-task` to specify the number of CPUs each worker should have.
+* Use SLURM's `--mem` to specify the memory each worker should have.
+
+## (Optional) Launching MPI tasks with HyperQueue under SLURM
+
+### Support for multi-node tasks in HyperQueue
+
+**Disclaimer:** Support for multi-node tasks is still in an experimental stage in HyperQueue. These instructions were tested on a specific system with HyperQueue v0.19.0. They may not work for your individual setup and are subject to change.
+
+A HyperQueue job may request multiple nodes using the `--nodes` option. Nodes assigned to this job are reserved exclusively and may not be used by other HyperQueue jobs until the job is finished.
+
+HyperQueue will set the environment variables `HQ_NODE_FILE` and `HQ_HOST_FILE` which contain a path to a file where each line is respectively the shortened or full host name of a node that was assigned to the job. For most systems using the shortened names in the `HQ_NODE_FILE` should be good enough.
+
+For convenience HyperQueue also provides the environment variable `HQ_NUM_NODES` which contains the number of nodes assigned to the job.
+
+### Launching MPI tasks in a HyperQueue job under SLURM
+
+The recommended way to launch MPI tasks under SLURM is using `srun`. Make sure to pass the parameters `--nodes=$HQ_NUM_NODES` and `--nodefile=$HQ_NODE_FILE` to ensure that your MPI tasks will be executed only on the nodes that were assigned to the HyperQueue job.
+
+As a reference, here is an example `srun` command which will launch two MPI tasks each on two nodes for a total of four MPI tasks. Note that each node has two CPUs available in this scenario. Read the following sections for further explanations of the options that were used:
+
+```shell
+srun --overlap --mem=0 --ntasks=4 --ntasks-per-node=2 --cpus-per-task=1 --nodes=$HQ_NUM_NODES --nodefile=$HQ_NODE_FILE <your-mpi-program-here>
+```
+
+A common problem which you may encounter is that the `srun` command simply gets stuck forever because it is unable to acquire the requested resources. This can happen due to HyperQueue also using `srun` to spawn HyperQueue workers on each node in an allocation. Since the HyperQueue workers are running at all times, SLURM thinks that the resources in the job allocation are occupied and therefore refuses to execute your `srun` command. You can fix this issue by adding the `--overlap` and `--mem=0` options, which will tell `srun` to share it's resources with other job steps and to use as much memory as available on each node.
+
+You also need to ensure that the total number of MPI tasks requested in `srun` does not exceed the total number of CPUs available in the nodes your job was assigned to. Otherwise you will encounter the same issue where `srun` gets stuck forever.
+
+Lastly, always specify the `--ntasks`, `--ntasks-per-node` and `--cpus-per-task` options in your `srun` command. This is required because otherwise `srun` will inherit the SLURM options that HyperQueue set to spawn the workers in the SLURM job allocation which will lead to undesired behavior.
+
 ## (Optional) Varying resource requirements per model (e.g. for multilevel / multifidelity)
 
-If your UM-Bridge server provides multiple models, you can specify different resource requirements for each of them. Define a separate job script ``hpc/hq_scripts/job_<model_name>.sh`` for each model that needs different resources than what you defined in the default ``job.sh``.
+If your UM-Bridge server provides multiple models, you can specify different resource requirements for each of them. Define a separate job script ``job_<model_name>.sh`` (in `hpc/slurm_scripts` or `hpc/hq_scripts` for SLURM and HyperQueue respectively) for each model that needs different resources than what you defined in the default ``job.sh``.
 
 ## (Optional) Running clients on your own machine while offloading runs to HPC
 
 Alternatively, a client may run on your own device. In order to connect UM-Bridge clients on your machine to the login node, you can create an SSH tunnel to the HPC system.
 
-```
+```shell
     ssh <username>@hpc.cluster.address -N -f -L 4242:<server hostname>:4242
     # start ssh tunnel
     # -N : do not execute remote command

--- a/hpc/slurm_scripts/job.sh
+++ b/hpc/slurm_scripts/job.sh
@@ -41,7 +41,6 @@ done
 echo "Model server responded"
 
 # Write server URL to file identified by HQ job ID.
-load_balancer_dir="."
 mkdir -p $UMBRIDGE_LOADBALANCER_COMM_FILEDIR
 echo "http://$host:$port" > "$UMBRIDGE_LOADBALANCER_COMM_FILEDIR/url-$SLURM_JOB_ID.txt"
 

--- a/hpc/slurm_scripts/job.sh
+++ b/hpc/slurm_scripts/job.sh
@@ -1,13 +1,11 @@
 #! /bin/bash
 
-#HQ --cpus=1
-#HQ --time-request=1m
-#HQ --time-limit=2m
-#HQ --stdout none
-#HQ --stderr none
+#SBATCH --partition=devel
+#SBATCH --ntasks=1
+#SBATCH --time=00:05:00
 
-# Launch model server, send back server URL
-# and wait to ensure that HQ won't schedule any more jobs to this allocation.
+
+# Launch model server, send back server URL and wait so that SLURM does not cancel the allocation.
 
 function get_available_port {
     # Define the range of ports to select from
@@ -43,7 +41,8 @@ done
 echo "Model server responded"
 
 # Write server URL to file identified by HQ job ID.
+load_balancer_dir="."
 mkdir -p $UMBRIDGE_LOADBALANCER_COMM_FILEDIR
-echo "http://$host:$port" > "$UMBRIDGE_LOADBALANCER_COMM_FILEDIR/url-$HQ_JOB_ID.txt"
+echo "http://$host:$port" > "$UMBRIDGE_LOADBALANCER_COMM_FILEDIR/url-$SLURM_JOB_ID.txt"
 
 sleep infinity # keep the job occupied

--- a/lib/umbridge.h
+++ b/lib/umbridge.h
@@ -21,6 +21,7 @@ namespace umbridge {
   class Model {
   public:
     Model(std::string name) : name(name) {}
+    virtual ~Model() {}
 
     virtual std::vector<std::size_t> GetInputSizes(const json& config_json = json::parse("{}")) const = 0;
     virtual std::vector<std::size_t> GetOutputSizes(const json& config_json = json::parse("{}")) const = 0;


### PR DESCRIPTION
## Summary
- Reimplemented the load balancer making it possible to select different scheduling strategies. At the moment the two options are pure SLURM and HyperQueue. 
- Made a simple CLI for specifying the scheduler, port and job submission delay.
- Prepared the code base for implementation of another communication layer between the load balancer and a job script in the future (i.e. network-based communication instead of the shared filesystem).
- Performed some general cleanup and added docs.

## Related issues
closes #80
