### PR TITLE
HPC: Fix port checking

### DIFF
--- a/hpc/Makefile
+++ b/hpc/Makefile
@@ -1,7 +1,10 @@
-all: build-load-balancer build-testmodel
+all: build-load-balancer build-is-port-free build-testmodel
 
 build-load-balancer:
 	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ LoadBalancer.cpp -o load-balancer -pthread
+
+build-is-port-free:
+	- g++ -O3 -std=c++17 is_port_free.cpp -o is_port_free
 
 build-testmodel:
 	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ ../models/testmodel/minimal-server.cpp -o testmodel -pthread

--- a/hpc/hq_scripts/job.sh
+++ b/hpc/hq_scripts/job.sh
@@ -18,7 +18,7 @@ function get_available_port {
     port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
 
     # Check if the port is in use
-    while lsof -Pi :$port -sTCP:LISTEN -t >/dev/null; do
+    until ./is_port_free $port; do
         # If the port is in use, generate a new random port number
         port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
     done

--- a/hpc/is_port_free.cpp
+++ b/hpc/is_port_free.cpp
@@ -1,0 +1,43 @@
+#include "../lib/httplib.h"
+
+#include <iostream>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+// Takes one integer argument - a port.
+// If the port is free, returns EXIT_SUCCESS; otherwise returns EXIT_FAILURE.
+// Note: Uses the Linux IPv4 protocol implementation!
+int main(int argc, char* argv[])
+{
+    // Get port to check from command line args
+    if (argc < 2) {
+        std::cerr << "Missing required positional argument: port" << std::endl;
+        return EXIT_FAILURE;
+    }
+    int port = std::atoi(argv[1]);
+
+    // Create socket
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd == -1) {
+        std::cerr << "Failed to create socket: " << std::strerror(errno) << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Set address to 0.0.0.0:port
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    // Attempt to assign address to socket
+    int success = bind(sockfd, (struct sockaddr*) &addr, sizeof(addr));
+
+    if (success == -1) {
+        return EXIT_FAILURE;
+    } else {
+        return EXIT_SUCCESS;
+    }
+}

--- a/hpc/slurm_scripts/job.sh
+++ b/hpc/slurm_scripts/job.sh
@@ -16,7 +16,7 @@ function get_available_port {
     port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
 
     # Check if the port is in use
-    while lsof -Pi :$port -sTCP:LISTEN -t >/dev/null; do
+    until ./is_port_free $port; do
         # If the port is in use, generate a new random port number
         port=$(shuf -i $MIN_PORT-$MAX_PORT -n 1)
     done


### PR DESCRIPTION
## Summary
Fixed the issue where a job would sometimes fail to start the model server due to the port being occupied.

## Details
- Previously, the command `lsof` was used to determine whether a port is free or not. However, without root permissions `lsof` can only show open connections for the user who ran the command (i.e. not for all the other users on the HPC cluster). 
- The issue is fixed by instead using a simple C++ program which attempts to bind a socket to an address for a given port.
> [!WARNING]  
> There is still a race condition that can occur in the time frame between the job script checking the port and the model server actually occupying it. However, I didn't encounter this issue yet during my tests and fixing it would require some major changes to the UM-Bridge interface used for serving models.

## Related Issues
closes #83, closes #48