### PR TITLE
Update LoadBalancer.hpp

### DIFF
--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -17,31 +17,22 @@
 // Using an external library (e.g. Boost) would be cleaner, but not worth the effort of managing another dependency.
 std::string get_command_output(const std::string& command) {
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), &pclose);
-  
+
     if (!pipe) {
         std::string error_msg = "Failed to run command: " + command + "\n"
-                            + "popen failed with error: " + std::strerror(errno) + "\n";
+                              + "popen failed with error: " + std::strerror(errno) + "\n"; 
         throw std::runtime_error(error_msg);
     }
-  
+
     // Buffer size can be small and is largely unimportant since most commands we use only return a single line.
     std::array<char, 128> buffer;
-    std::string output, line;
-    std::regex job_id_regex(R"(^\d+$)");
+    std::string output;
     while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get())) {
-        line = buffer.data();
-        line.erase(line.find_last_not_of(" \n\r\t") + 1);
-        if(std::regex_match(line, job_id_regex)){
-                output = line;
-        }
+        output += buffer.data();
     }
-  
-    if(output.empty()){
-        throw std::runtime_error("no Job ID found");
-    }
+
     return output;
 }
-
 
 // Wait until a file exists using polling.
 void wait_for_file(const std::filesystem::path& file_path, std::chrono::milliseconds polling_cycle) {

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -9,7 +9,8 @@
 #include <memory>
 #include <string>
 #include <vector>
-
+#include <regex>
+#include <sstream>
 
 // Run a shell command and get the result.
 // Warning: Prone to injection, do not call with user-supplied arguments.
@@ -134,8 +135,16 @@ public:
         command.addOption("--parsable");
         std::string output = get_command_output(command.toString());
 
-        id = output.substr(0, output.find(';'));
-        remove_trailing_newline(id);
+    	std::regex job_id_regex(R"(^\d+$)");
+	std::istringstream stream(output);
+    	std::string line;
+
+    	while (std::getline(stream, line)) {
+		if (std::regex_match(line, job_id_regex)) {
+			id = line;
+                }
+        }
+	remove_trailing_newline(id);
     }
 
     ~SlurmJob() override {

--- a/hpc/LoadBalancer.hpp
+++ b/hpc/LoadBalancer.hpp
@@ -135,13 +135,14 @@ public:
         command.addOption("--parsable");
         std::string output = get_command_output(command.toString());
 
-    	std::regex job_id_regex(R"(^\d+$)");
+	std::regex job_id_regex(R"(^(\d+)(?:;[a-zA-Z0-9_-]+)?$)");
 	std::istringstream stream(output);
     	std::string line;
 
     	while (std::getline(stream, line)) {
-		if (std::regex_match(line, job_id_regex)) {
-			id = line;
+		std::smatch match;
+		if (std::regex_match(line, match, job_id_regex)) {
+			id = match[1];
                 }
         }
 	remove_trailing_newline(id);

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -93,7 +93,8 @@ class HTTPModel(Model):
         inputParams["name"] = self.name
         inputParams["input"] = parameters
         inputParams["config"] = config
-        response = requests.post(f"{self.url}/Evaluate", json=inputParams).json()
+        response = requests.post(f"{self.url}/Evaluate", json=inputParams)
+        response = response.json()
 
         if "error" in response:
             raise Exception(f'Model returned error of type {response["error"]["type"]}: {response["error"]["message"]}')


### PR DESCRIPTION
modified the get_command_output function to ignore the initial lines of a HPC cluster's output until the job id is given