### PR TITLE
Fix two failing CI

### DIFF
--- a/.github/workflows/client-python-tinyDA.yml
+++ b/.github/workflows/client-python-tinyDA.yml
@@ -28,7 +28,7 @@ jobs:
           apt update && DEBIAN_FRONTEND="noninteractive" apt install -y python3-pip python3-venv
           python3 -m venv venv
           . venv/bin/activate
-          pip3 install papermill umbridge tinyDA ipykernel
+          pip3 install papermill umbridge tinyDA ipykernel ray
        -
         name: Build and run
         run: |

--- a/benchmarks/testbenchmark/benchmark-server.py
+++ b/benchmarks/testbenchmark/benchmark-server.py
@@ -14,7 +14,7 @@ class Benchmark(umbridge.Model):
 
     def __call__(self, parameters, config):
         model = umbridge.HTTPModel(self.model_url, "forward")
-        posterior = scipy.stats.norm.logpdf(model(parameters)[0][0], 2.0, 1)  # logpdf args: x, loc, scale
+        posterior = float(scipy.stats.norm.logpdf(model(parameters)[0][0], 2.0, 1))  # logpdf args: x, loc, scale
         return [[posterior]]
 
     def supports_evaluate(self):

--- a/hpc/Makefile
+++ b/hpc/Makefile
@@ -1,10 +1,10 @@
 all: build-load-balancer build-is-port-free build-testmodel
 
 build-load-balancer:
-	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ LoadBalancer.cpp -o load-balancer -pthread
+	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ LoadBalancer.cpp -o load-balancer -pthread -static-libstdc++ -static-libgcc
 
 build-is-port-free:
-	- g++ -O3 -std=c++17 is_port_free.cpp -o is_port_free
+	- g++ -O3 -std=c++17 is_port_free.cpp -o is_port_free -static-libstdc++ -static-libgcc
 
 build-testmodel:
-	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ ../models/testmodel/minimal-server.cpp -o testmodel -pthread
+	- g++ -O3 -Wno-unused-result -std=c++17 -I../lib/ ../models/testmodel/minimal-server.cpp -o testmodel -pthread -static-libstdc++ -static-libgcc


### PR DESCRIPTION
client-python-tinyDA fails because of missing dependency. This is now added.

benchmark-testbenchmark fails because `jsonschema` does not recognise numpy float as a number. The output is now casted to a float before returning.