### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/client-python-tinyDA.yml
+++ b/.github/workflows/client-python-tinyDA.yml
@@ -28,7 +28,7 @@ jobs:
           apt update && DEBIAN_FRONTEND="noninteractive" apt install -y python3-pip python3-venv
           python3 -m venv venv
           . venv/bin/activate
-          pip3 install papermill umbridge tinyDA ipykernel
+          pip3 install papermill umbridge tinyDA ipykernel ray
        -
         name: Build and run
         run: |

--- a/benchmarks/testbenchmark/benchmark-server.py
+++ b/benchmarks/testbenchmark/benchmark-server.py
@@ -14,7 +14,7 @@ class Benchmark(umbridge.Model):
 
     def __call__(self, parameters, config):
         model = umbridge.HTTPModel(self.model_url, "forward")
-        posterior = scipy.stats.norm.logpdf(model(parameters)[0][0], 2.0, 1)  # logpdf args: x, loc, scale
+        posterior = float(scipy.stats.norm.logpdf(model(parameters)[0][0], 2.0, 1))  # logpdf args: x, loc, scale
         return [[posterior]]
 
     def supports_evaluate(self):


### PR DESCRIPTION
client-python-tinyDA fails because of missing dependency. This is now added.

benchmark-testbenchmark fails because jsonschema does not recognise numpy float as a number. The output is now casted to a float before returning.