### PR TITLE
Add explicit option to use shared memory and fixes bug when input list is empty

### DIFF
--- a/.github/workflows/sharedmemtest-c++.yml
+++ b/.github/workflows/sharedmemtest-c++.yml
@@ -34,7 +34,8 @@ jobs:
        -
         name: Build and run
         run: |
-          cd clients/c++ && ./build.sh && checkShMem=$(./http-client model:4242 | grep -o "not accessible" || true); echo "CheckShMem=$checkShMem" >> $GITHUB_ENV
+          cd clients/c++ && sed -i -e 's|client(host, "forward")|client(host, "forward", true)|' http-client.cpp
+          ./build.sh && checkShMem=$(./http-client model:4242 | grep -o "not accessible" || true); echo "CheckShMem=$checkShMem" >> $GITHUB_ENV
        -
         name: Check if Shared Memory is used
         if: env.CheckShMem == 'not accessible'

--- a/.github/workflows/sharedmemtest-python.yml
+++ b/.github/workflows/sharedmemtest-python.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           python3 -m venv venv
           . venv/bin/activate && pip3 install umbridge
-          cd clients/python && checkShMem=$(python3 umbridge-client.py http://model:4242 | grep -o "not accessible" || true); echo "CheckShMem=$checkShMem" >> $GITHUB_ENV
+          cd clients/python && sed -i -e 's|umbridge.HTTPModel(args.url, "forward")|umbridge.HTTPModel(args.url, "forward", True)|' umbridge-client.py
+          checkShMem=$(python3 umbridge-client.py http://model:4242 | grep -o "not accessible" || true); echo "CheckShMem=$checkShMem" >> $GITHUB_ENV
        - 
         name: Check if Shared Memory is used
         if: env.CheckShMem == 'not accessible'

--- a/lib/umbridge.h
+++ b/lib/umbridge.h
@@ -153,7 +153,7 @@ namespace umbridge {
   class HTTPModel : public Model {
   public:
 
-    HTTPModel(std::string host, std::string name, httplib::Headers headers = httplib::Headers())
+    HTTPModel(std::string host, std::string name, bool useShMem = false, httplib::Headers headers = httplib::Headers())
     : Model(name), cli(host.c_str()), headers(headers)
     {
       // Check if requested model is available on server
@@ -183,18 +183,20 @@ namespace umbridge {
       }
 #ifdef SUPPORT_POSIX_SHMEM
       // Test whether client and server are able to communicate through shared memory. Disables ShMem if test fails.
-      unsigned long int tid = pthread_self();
-      request_body["tid"] = std::to_string(tid);
-      std::vector<double> testvec = {12345.0};
-      SharedMemoryVector shmem_input(testvec, "/umbridge_test_shmem_in_" + std::to_string(tid));
-      SharedMemoryVector shmem_output(1, "/umbridge_test_shmem_out_" + std::to_string(tid), true);
-      auto res = cli.Post("/TestShMem", headers, request_body.dump(), "application/json");
+      if (useShMem) {
+        unsigned long int tid = pthread_self();
+        request_body["tid"] = std::to_string(tid);
+        std::vector<double> testvec = {12345.0};
+        SharedMemoryVector shmem_input(testvec, "/umbridge_test_shmem_in_" + std::to_string(tid));
+        SharedMemoryVector shmem_output(1, "/umbridge_test_shmem_out_" + std::to_string(tid), true);
+        auto res = cli.Post("/TestShMem", headers, request_body.dump(), "application/json");
 
-      if (shmem_output.GetVector()[0] != testvec[0]) {
-        std::cout << "Server not accessible via shared memory" << std::endl;
-      } else {
-        supportsShMem = true;
-        std::cout << "Server accessible via shared memory" << std::endl;
+        if (shmem_output.GetVector()[0] != testvec[0]) {
+          std::cout << "Server not accessible via shared memory" << std::endl;
+        } else {
+          supportsShMem = true;
+          std::cout << "Server accessible via shared memory" << std::endl;
+        }
       }
 #endif
     }

--- a/lib/umbridge.h
+++ b/lib/umbridge.h
@@ -192,7 +192,7 @@ namespace umbridge {
         auto res = cli.Post("/TestShMem", headers, request_body.dump(), "application/json");
 
         if (shmem_output.GetVector()[0] != testvec[0]) {
-          std::cout << "Server not accessible via shared memory" << std::endl;
+          std::cout << "Server not accessible via shared memory. Using HTTP instead." << std::endl;
         } else {
           supportsShMem = true;
           std::cout << "Server accessible via shared memory" << std::endl;

--- a/lib/umbridge.h
+++ b/lib/umbridge.h
@@ -241,7 +241,9 @@ namespace umbridge {
         unsigned int tid = pthread_self();
         std::vector<std::unique_ptr<SharedMemoryVector>> shmem_inputs;
         for (int i = 0; i < inputs.size(); i++) {
-          shmem_inputs.push_back(std::make_unique<SharedMemoryVector>(inputs[i], "/umbridge_in_" + std::to_string(tid) + "_" + std::to_string(i)));
+          if (inputs[i].size() > 0) { // Handles edges with empty vector
+            shmem_inputs.push_back(std::make_unique<SharedMemoryVector>(inputs[i], "/umbridge_in_" + std::to_string(tid) + "_" + std::to_string(i)));
+          }
         }
         std::vector<std::unique_ptr<SharedMemoryVector>> shmem_outputs;
         std::vector<std::size_t> output_sizes = GetOutputSizes(config_json); // Potential optimization: Avoid this call (e.g. share output memory with appropriate dimension from server side, sync with client via POSIX semaphore)
@@ -728,8 +730,13 @@ namespace umbridge {
 
       std::vector<std::vector<double>> inputs;
       for (int i = 0; i < request_body["shmem_num_inputs"].get<int>(); i++) {
-        SharedMemoryVector shmem_input(request_body["shmem_size_" + std::to_string(i)].get<int>(), request_body["shmem_name"].get<std::string>() + "_in_" + request_body["tid"].get<std::string>() + "_" + std::to_string(i), false);
-        inputs.push_back(shmem_input.GetVector());
+        if (request_body["shmem_size_" + std::to_string(i)] == 0) { // Handles edge case with empty vector
+        inputs.push_back(std::vector<double>{});
+        }
+        else{
+          SharedMemoryVector shmem_input(request_body["shmem_size_" + std::to_string(i)].get<int>(), request_body["shmem_name"].get<std::string>() + "_in_" + request_body["tid"].get<std::string>() + "_" + std::to_string(i), false);
+          inputs.push_back(shmem_input.GetVector());
+        }
       }
       std::vector<std::unique_ptr<SharedMemoryVector>> shmem_outputs;
       for (int i = 0; i < model.GetOutputSizes().size(); i++) {

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -142,13 +142,16 @@ class HTTPModel(Model):
             inputParams["shmem_num_inputs"] = len(parameters)
             buffers = []
 
-            if len(parameters[0]) > 0: # Edge case where input is an empty list
-                for i in range(len(parameters)):
-                    inputParams["shmem_size_" + str(i)] = len(parameters[i])
+            for i in range(len(parameters)):
+                inputParams["shmem_size_" + str(i)] = len(parameters[i])
+                if len(parameters[i]) > 0:
                     shm_c_in = shared_memory.SharedMemory(inputParams["shmem_name"] + "_in_" + str(tid) + f"_{i}", create=True, size=len(parameters[i])*8)
                     raw_shmem_input = np.ndarray((len(parameters[i]),), dtype=np.float64, buffer=shm_c_in.buf)
                     raw_shmem_input[:] = parameters[i]
                     buffers.append(shm_c_in)
+                else: # Handles edge case with empty list
+                    continue
+                
             output_sizes = self.get_output_sizes(config)
 
             for i in range(len(output_sizes)):
@@ -444,10 +447,13 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
 
         parameters = []
         for i in range(req_json["shmem_num_inputs"]):
-            shm_c_in = shared_memory.SharedMemory(req_json["shmem_name"] + "_in_" + str(req_json["tid"]) + f"_{i}", False, req_json[f"shmem_size_{i}"])
-            raw_shmem_parameter = np.ndarray((req_json[f"shmem_size_{i}"],), dtype=np.float64, buffer=shm_c_in.buf)
-            parameters.append(raw_shmem_parameter.tolist())
-            shm_c_in.close()
+            if req_json[f"shmem_size_{i}"] == 0: # Handles edge case with empty list
+                parameters.append([])
+            else:
+                shm_c_in = shared_memory.SharedMemory(req_json["shmem_name"] + "_in_" + str(req_json["tid"]) + f"_{i}", False, req_json[f"shmem_size_{i}"])
+                raw_shmem_parameter = np.ndarray((req_json[f"shmem_size_{i}"],), dtype=np.float64, buffer=shm_c_in.buf)
+                parameters.append(raw_shmem_parameter.tolist())
+                shm_c_in.close()
 
         # Check if parameter dimensions match model input sizes
         if len(parameters) != len(model.get_input_sizes(config)):

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -87,7 +87,7 @@ class HTTPModel(Model):
             shm_c_out.unlink()
 
             if(result[0] != testvec[0]):
-                print("Server not accessible via shared memory")
+                print("Server not accessible via shared memory. Using HTTP instead.")
             else:
                 self.__supports_shmem= True
                 print("Server accessible via shared memory")

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -51,7 +51,7 @@ def supported_models(url):
   return response["models"]
 
 class HTTPModel(Model):
-    def __init__(self, url, name):
+    def __init__(self, url, name, use_shmem=False):
         super().__init__(name)
         self.url = url
 
@@ -67,29 +67,30 @@ class HTTPModel(Model):
         self.__supports_apply_hessian = response["support"].get("ApplyHessian", False)
         self.__supports_shmem = False
 
-        #Test whether client and server are able to communicate through shared memory. Disables ShMem if test fails.
-        testvec = [12345.0]
-        tid = threading.get_native_id()
-        input["tid"] = str(tid)
-        shm_c_in = shared_memory.SharedMemory("/umbridge_test_shmem_in_" + str(tid), True, 8)
-        raw_shmem_input = np.ndarray(1, dtype=np.float64, buffer=shm_c_in.buf)
-        raw_shmem_input[:] = testvec[0]
-        shm_c_out = shared_memory.SharedMemory("/umbridge_test_shmem_out_" + str(tid), create=True, size=8)
-        raw_shmem_output = np.ndarray(1, dtype=np.float64, buffer=shm_c_out.buf)
-        try: response = requests.post(f"{self.url}/TestShMem", json=input).json()
-        except: pass
-        result = []
-        result.append(raw_shmem_output.tolist()[0])
-        shm_c_in.close()
-        shm_c_in.unlink()
-        shm_c_out.close()
-        shm_c_out.unlink()
+        if use_shmem:
+            #Test whether client and server are able to communicate through shared memory. Disables ShMem if test fails.
+            testvec = [12345.0]
+            tid = threading.get_native_id()
+            input["tid"] = str(tid)
+            shm_c_in = shared_memory.SharedMemory("/umbridge_test_shmem_in_" + str(tid), True, 8)
+            raw_shmem_input = np.ndarray(1, dtype=np.float64, buffer=shm_c_in.buf)
+            raw_shmem_input[:] = testvec[0]
+            shm_c_out = shared_memory.SharedMemory("/umbridge_test_shmem_out_" + str(tid), create=True, size=8)
+            raw_shmem_output = np.ndarray(1, dtype=np.float64, buffer=shm_c_out.buf)
+            try: response = requests.post(f"{self.url}/TestShMem", json=input).json()
+            except: pass
+            result = []
+            result.append(raw_shmem_output.tolist()[0])
+            shm_c_in.close()
+            shm_c_in.unlink()
+            shm_c_out.close()
+            shm_c_out.unlink()
 
-        if(result[0] != testvec[0]):
-            print("Server not accessible via shared memory")
-        else:
-            self.__supports_shmem= True
-            print("Server accessible via shared memory")
+            if(result[0] != testvec[0]):
+                print("Server not accessible via shared memory")
+            else:
+                self.__supports_shmem= True
+                print("Server accessible via shared memory")
 
 
     def get_input_sizes(self, config={}):

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -122,7 +122,7 @@ class HTTPModel(Model):
     def supports_shmem(self):
         return self.__supports_shmem
     
-    def __check_input_is_list_of_lists(self,parameters):
+    def __check_input_is_list_of_lists(self, parameters):
         if not isinstance(parameters, list):
             raise Exception("Parameters must be a list of lists!")
         if not all(isinstance(x, list) for x in parameters):
@@ -142,12 +142,13 @@ class HTTPModel(Model):
             inputParams["shmem_num_inputs"] = len(parameters)
             buffers = []
 
-            for i in range(len(parameters)):
-                inputParams["shmem_size_" + str(i)] = len(parameters[i])
-                shm_c_in = shared_memory.SharedMemory(inputParams["shmem_name"] + "_in_" + str(tid) + f"_{i}", create=True, size=len(parameters[i])*8)
-                raw_shmem_input = np.ndarray((len(parameters[i]),), dtype=np.float64, buffer=shm_c_in.buf)
-                raw_shmem_input[:] = parameters[i]
-                buffers.append(shm_c_in)
+            if len(parameters[0]) > 0: # Edge case where input is an empty list
+                for i in range(len(parameters)):
+                    inputParams["shmem_size_" + str(i)] = len(parameters[i])
+                    shm_c_in = shared_memory.SharedMemory(inputParams["shmem_name"] + "_in_" + str(tid) + f"_{i}", create=True, size=len(parameters[i])*8)
+                    raw_shmem_input = np.ndarray((len(parameters[i]),), dtype=np.float64, buffer=shm_c_in.buf)
+                    raw_shmem_input[:] = parameters[i]
+                    buffers.append(shm_c_in)
             output_sizes = self.get_output_sizes(config)
 
             for i in range(len(output_sizes)):


### PR DESCRIPTION
Added a flag in `HTTPModel` to use shared memory if it's available. Off by default and falls back to HTTP if shared memory is unavailable for some reason.

Also fixes bug where the shared memory creation fails when input list is empty.